### PR TITLE
Add support for private tenant api_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ lane :applivery_ios do
 end
 ```
 
-You could use this id to open your build information in applivery like:
+You could use this id to open your build information in Applivery like:
 
 ```
 https://dashboard.applivery.io/{YOUR_WORKSPACE_SLUG}/apps/{YOUR_APP_SLUG}/builds?id={THIS_BUILD_ID}
 ```
+Or to create a direct link to a specific build in your enterprise store:
+```
+"https://{YOUR_WORKSPACE_SLUG}.applivery.io/#{YOUR_APP_SLUG}?os={APP_OS}&build=#{THIS_BUILD_ID}"
+```
+Where `APP_OS` can be `ios|android`.
 
 ## Run tests for this plugin
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ end
 You could use this id to open your build information in applivery like:
 
 ```
-https://dashboard.applivery.io/apps/apps/{YOUR_APP_SLUG}/builds?id={THIS_BUILD_ID}
+https://dashboard.applivery.io/{YOUR_WORKSPACE_SLUG}/apps/{YOUR_APP_SLUG}/builds?id={THIS_BUILD_ID}
 ```
 
 ## Run tests for this plugin

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The above examples are the most simple configuration you can have but you can ad
 | `changelog`              | Release notes                        | NO        | string -> i.e.: "Bug fixing"       |
 | `tags`                   | Tags to identify the build           | NO        | string -> comma separated. i.e.: `"RC1, QA"` |
 | `filter`                 | List of groups that will be notified | NO        | string -> comma separated + special chars. i.e.: `"group1,group2\|group3"` =  (grupo1 AND grupo2) OR (grupo3) |
-| `build_path`             | Build path to the APK / IPA file     | NO        | string -> by default it takes the IPA/APK build path |
+| `build_path`             | Build path to the APK/AAB/IPA file   | NO        | string -> by default it takes the IPA/APK build path |
 
 ## Shared Value
 Once your build is uploaded successfuly, the new generated build ID is provided by a Shared Value `APPLIVERY_BUILD_ID` that can be accesed in your lane with `lane_context[SharedValues::APPLIVERY_BUILD_ID]`

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The above examples are the most simple configuration you can have but you can ad
 |--------------------------|--------------------------------------|-----------|--------------|
 | `app_token`              | Applivery App Token                  | YES       | string -> Available in the App Settings |
 | `name`                   | Applivery Build name                 | NO        | string-> i.e.: "RC 1.0"       |
-| `notify_collaborators`   | Notify Collaborators after deploy    | NO        | booletan -> i.e.: `true` / `false` |
-| `notify_employees`       | Notify Employees after deploy        | NO        | booletan -> i.e.: `true` / `false` |
+| `notify_collaborators`   | Notify Collaborators after deploy    | NO        | boolean -> i.e.: `true` / `false` |
+| `notify_employees`       | Notify Employees after deploy        | NO        | boolean -> i.e.: `true` / `false` |
 | `notify_message`         | Notification message                 | NO        | string -> i.e.: "Enjoy the new version!" |
 | `changelog`              | Release notes                        | NO        | string -> i.e.: "Bug fixing"       |
 | `tags`                   | Tags to identify the build           | NO        | string -> comma separated. i.e.: `"RC1, QA"` |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The above examples are the most simple configuration you can have but you can ad
 | `tags`                   | Tags to identify the build           | NO        | string -> comma separated. i.e.: `"RC1, QA"` |
 | `filter`                 | List of groups that will be notified | NO        | string -> comma separated + special chars. i.e.: `"group1,group2\|group3"` =  (grupo1 AND grupo2) OR (grupo3) |
 | `build_path`             | Build path to the APK/AAB/IPA file   | NO        | string -> by default it takes the IPA/APK build path |
+| `api_url`                | Your private tenant API URL          | NO        | string -> Example: https://api.applivery-mycompany.com |
 
 ## Shared Value
 Once your build is uploaded successfuly, the new generated build ID is provided by a Shared Value `APPLIVERY_BUILD_ID` that can be accesed in your lane with `lane_context[SharedValues::APPLIVERY_BUILD_ID]`

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The above examples are the most simple configuration you can have but you can ad
 | `tags`                   | Tags to identify the build           | NO        | string -> comma separated. i.e.: `"RC1, QA"` |
 | `filter`                 | List of groups that will be notified | NO        | string -> comma separated + special chars. i.e.: `"group1,group2\|group3"` =  (grupo1 AND grupo2) OR (grupo3) |
 | `build_path`             | Build path to the APK/AAB/IPA file   | NO        | string -> by default it takes the IPA/APK build path |
-| `api_url`                | Your private tenant API URL          | NO        | string -> Example: https://api.applivery-mycompany.com |
+| `api_url`                | Your private tenant API URL          | NO        | string -> Example: https://upload.applivery-mycompany.com |
 
 ## Shared Value
 Once your build is uploaded successfuly, the new generated build ID is provided by a Shared Value `APPLIVERY_BUILD_ID` that can be accesed in your lane with `lane_context[SharedValues::APPLIVERY_BUILD_ID]`

--- a/lib/fastlane/plugin/applivery/actions/applivery_action.rb
+++ b/lib/fastlane/plugin/applivery/actions/applivery_action.rb
@@ -13,7 +13,8 @@ module Fastlane
         build_path = params[:build_path]
         build = Faraday::UploadIO.new(build_path, 'application/octet-stream') if build_path && File.exist?(build_path)
 
-        conn = Faraday.new(url: 'https://upload.applivery.io') do |faraday|
+        api_url = params[:api_url]
+        conn = Faraday.new(url: api_url) do |faraday|
           faraday.request :multipart
           faraday.request :url_encoded
           # faraday.response :logger
@@ -79,6 +80,10 @@ module Fastlane
         else
           return apk_path
         end
+      end
+
+      def self.api_url
+        return 'https://upload.applivery.io'
       end
 
       def self.description
@@ -147,6 +152,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :filter,
             env_name: "APPLIVERY_FILTER",
             description: "List of groups that will be notified",
+            optional: true,
+            type: String),
+
+          FastlaneCore::ConfigItem.new(key: :api_url,
+            env_name: "APPLIVERY_API_URL",
+            description: "Your private tenant API URL",
+            default_value: self.api_url,
             optional: true,
             type: String),
         ]

--- a/lib/fastlane/plugin/applivery/actions/applivery_action.rb
+++ b/lib/fastlane/plugin/applivery/actions/applivery_action.rb
@@ -56,7 +56,7 @@ module Fastlane
         UI.verbose "Response Body: #{response.body}"
         status = response.body["status"]
         if status
-          UI.success "Build uploaded succesfully! 💪"
+          UI.success "Build uploaded successfully! 💪"
           Actions.lane_context[SharedValues::APPLIVERY_BUILD_ID] = response.body["data"]["id"]
         else
           UI.error "Oops! Something went wrong.... 🔥"


### PR DESCRIPTION
Add support for private tenant `api_url` to support private tenant customers and update README:
- Add workspace slug to example and add example of how to create direct enterprise store link to specific build id
- Fixed minor spelling errors